### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Julia package to optimally solve the [multiway number partitioning](htt
 using a JuMP model with mixed-integer programming.
 
 There is one main function `partition` which tries to accomplish the following task:
-given a collection of numbers `S` and a number `k`, try to partition `S` into `k` subsets of roughly equal size.
+given a collection of numbers `S` and a number `k`, try to partition `S` into `k` subsets of roughly equal sum.
 
 For example:
 ```julia


### PR DESCRIPTION
I think I wrote `size` when thinking of the [example](https://github.com/beacon-biosignals/MultiwayNumberPartitioning.jl/blob/main/example/example.jl) but in the formulation here, it should be "sum" instead (in the example, the sum corresponds to the size of the groups).