### PR TITLE
bump compat

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5' # earliest supported version
+          - '1.6' # earliest supported version
           - '1' # current release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MultiwayNumberPartitioning"
 uuid = "76062700-569f-48fc-9444-88b66f57fbe9"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -10,10 +10,10 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 Chain = "0.4"
 DataFrames = "1"
-HiGHS = "0.2"
-JuMP = "0.21"
+HiGHS = "1"
+JuMP = "1"
 StableRNGs = "1"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"


### PR DESCRIPTION
also bumped Julia version to the LTS, which is required anyway by JuMP

closes https://github.com/beacon-biosignals/MultiwayNumberPartitioning.jl/pull/7